### PR TITLE
Cambios solicitados por Felipe Hoffa

### DIFF
--- a/config/locales/schedule.es-CL.yml
+++ b/config/locales/schedule.es-CL.yml
@@ -1,7 +1,7 @@
 es-CL:
 
   schedule_day_one:
-    -
+    
       time: "8:00 - 9:30"
       visualization: "global"
       type: "break"
@@ -237,7 +237,7 @@ es-CL:
         - line: "Faster development with static types"
       track3:
         - line: "Felipe Hoffa:"
-        - line: "De open data a accessible data: Censo 2002 y BigQuery"
+        - line: "BigData: De open data a accessible data: Censo 2002 y Google BigQuery"
     -
       time: "16:20 - 16:50"
       visualization: ""

--- a/config/locales/schedule.es-CL.yml
+++ b/config/locales/schedule.es-CL.yml
@@ -1,7 +1,6 @@
 es-CL:
 
   schedule_day_one:
-    
     -
       time: "8:00 - 9:30"
       visualization: "global"

--- a/config/locales/schedule.es-CL.yml
+++ b/config/locales/schedule.es-CL.yml
@@ -2,6 +2,7 @@ es-CL:
 
   schedule_day_one:
     
+    -
       time: "8:00 - 9:30"
       visualization: "global"
       type: "break"

--- a/config/locales/speakers.en.yml
+++ b/config/locales/speakers.en.yml
@@ -115,7 +115,7 @@ dive deep, see what we can find, and come out as better developers!"
       name: "Felipe Hoffa"
       occupation: "Developer Relations Engineer en Google"
       contact: "felipehoffa"
-      talk_name: "De open data a accessible data - el censo Chile 2002 y BigQuery"
+      talk_name: "De open data a accessible data - el censo Chile 2002 y Google BigQuery"
       talk_desc: ""
       country: "Chile"
     -

--- a/config/locales/speakers.en.yml
+++ b/config/locales/speakers.en.yml
@@ -115,7 +115,7 @@ dive deep, see what we can find, and come out as better developers!"
       name: "Felipe Hoffa"
       occupation: "Developer Relations Engineer en Google"
       contact: "felipehoffa"
-      talk_name: "De open data a accessible data - el censo Chile 2002 y Google BigQuery"
+      talk_name: "BigData: De open data a accessible data - el censo Chile 2002 y Google BigQuery"
       talk_desc: ""
       country: "Chile"
     -

--- a/config/locales/speakers.es-CL.yml
+++ b/config/locales/speakers.es-CL.yml
@@ -115,7 +115,7 @@ dive deep, see what we can find, and come out as better developers!"
       name: "Felipe Hoffa"
       occupation: "Developer Relations Engineer en Google"
       contact: "felipehoffa"
-      talk_name: "De open data a accessible data - el censo Chile 2002 y BigQuery"
+      talk_name: "BigData: De open data a accessible data - el censo Chile 2002 y Google BigQuery"
       talk_desc: ""
       country: "Chile"
     -


### PR DESCRIPTION
- El nombre correcto es "Google BigQuery", no "BigQuery" a secas (está bien hablar de "BigQuery" después de haber hecho la presentación oficial).
- Quería agregarle "bigdata" a la descripción. Hablando con personas que miraron el schedule, no les quedó claro a qué temática pertenece.
